### PR TITLE
Release 3.0.0.dev1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
 install:
   - pip install .[testing]
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - pip install .[testing]
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Explicit support for Python 3.9
+- Added `layaberr.flask_restx.add_error_handler` function to return a string representation of an error as a specific HTTP error.
 
 ### Fixed
 - Add documentation to `layaberr.flask_restx.add_error_handlers`.
+
+### Changed
+- `layaberr.flask_restx.add_bad_request_exception_handler` will now raise a JSON string as a response. Instead of a JSON dict with the string value linked to `message` key.
+- `layaberr.flask_restx.add_unauthorized_exception_handler` will now raise a JSON string as a response. Instead of a JSON dict with the string value linked to `message` key.
+- `layaberr.flask_restx.add_forbidden_exception_handler` will now raise a JSON string as a response. Instead of a JSON dict with the string value linked to `message` key.
+- `layaberr.flask_restx.add_exception_handler` will now raise a JSON string as a response. Instead of a JSON dict with the string value linked to `message` key.
+- `layaberr.flask_restx.add_failed_validation_handler` will not contains `message` key anymore and the content of `fields` key will not be the JSON response. So a list is now returned instead of a dict containing a list.
+
+### Removed
+- `layaberr.flask_restx` will not log exceptions anymore. Logging is deferred to the REST API.
+- `layaberr.flask_restx.add_bad_request_exception_handler` is not available anymore.
+- `layaberr.flask_restx.add_unauthorized_exception_handler` is not available anymore.
+- `layaberr.flask_restx.add_forbidden_exception_handler` is not available anymore.
+- `layaberr.flask_restx.add_exception_handler` is not available anymore.
 
 ## [3.0.0.dev0] - 2020-10-02
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Explicit support for Python 3.9
+
+### Fixed
+- Add documentation to `layaberr.flask_restx.add_error_handlers`.
 
 ## [3.0.0.dev0] - 2020-10-02
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.0.0.dev1] - 2020-10-07
 ### Added
 - Explicit support for Python 3.9
 - Added `layaberr.flask_restx.add_error_handler` function to return a string representation of an error as a specific HTTP error.
@@ -38,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/layaberr/compare/v3.0.0.dev0...HEAD
+[Unreleased]: https://github.com/Colin-b/layaberr/compare/v3.0.0.dev1...HEAD
+[3.0.0.dev1]: https://github.com/Colin-b/layaberr/compare/v3.0.0.dev0...v3.0.0.dev1
 [3.0.0.dev0]: https://github.com/Colin-b/layaberr/compare/v2.2.0...v3.0.0.dev0
 [2.2.0]: https://github.com/Colin-b/layaberr/releases/tag/v2.2.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://travis-ci.com/Colin-b/layaberr"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/layaberr.svg?branch=master"></a>
 <a href="https://travis-ci.com/Colin-b/layaberr"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/layaberr"><img alt="Number of tests" src="https://img.shields.io/badge/tests-22 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/layaberr"><img alt="Number of tests" src="https://img.shields.io/badge/tests-24 passed-blue"></a>
 <a href="https://pypi.org/project/layaberr/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/layaberr"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ raise ValidationFailed(received_data, message="This is the error message")
 
 Will result in the following JSON response sent to the client:
 ```json
-{"fields":  [{"item":  1, "field_name":  "", "messages": ["This is the error message"]}]}
+[{"item":  1, "field_name":  "", "messages": ["This is the error message"]}]
 ```
 
 ##### Error specific to a field in a received dictionary
@@ -65,7 +65,7 @@ raise ValidationFailed(received_data, errors={"field 1": ["Invalid value"]})
 
 Will result in the following JSON response sent to the client:
 ```json
-{"fields":  [{"item":  1, "field_name":  "field 1", "messages": ["Invalid value"]}]}
+[{"item":  1, "field_name":  "field 1", "messages": ["Invalid value"]}]
 ```
 
 ##### Error specific to a field in a received list of dictionaries
@@ -81,7 +81,7 @@ raise ValidationFailed(received_data, errors={1: {"field 1": ["Invalid value"]}}
 
 Will result in the following JSON response sent to the client:
 ```json
-{"fields":  [{"item":  2, "field_name":  "field 1", "messages": ["Invalid value"]}]}
+[{"item":  2, "field_name":  "field 1", "messages": ["Invalid value"]}]
 ```
 
 #### Unauthorized
@@ -98,7 +98,7 @@ raise Unauthorized("The exception message")
 
 Will result in the following JSON response sent to the client:
 ```json
-{"message":  "The exception message"}
+"The exception message"
 ```
 
 #### Forbidden
@@ -115,7 +115,7 @@ raise Forbidden("The exception message")
 
 Will result in the following JSON response sent to the client:
 ```json
-{"message":  "The exception message"}
+"The exception message"
 ```
 
 #### Exception (this is the default handler)
@@ -130,7 +130,15 @@ raise Exception("The exception message")
 
 Will result in the following JSON response sent to the client:
 ```json
-{"message":  "The exception message"}
+"The exception message"
+```
+
+## Flask-RestX
+
+For the default handlers to work fine, you will have to disable the addition of "message" key within the exception results.
+
+```python
+application.config["ERROR_INCLUDE_MESSAGE"] = False
 ```
 
 ## How to install

--- a/layaberr/flask_restx.py
+++ b/layaberr/flask_restx.py
@@ -1,6 +1,6 @@
-from typing import Union, List, Dict
+from typing import Union, List, Dict, Type
 import logging
-from http import HTTPStatus
+import http
 
 import flask_restx
 from werkzeug.exceptions import Unauthorized, Forbidden, BadRequest
@@ -9,115 +9,27 @@ from werkzeug.exceptions import Unauthorized, Forbidden, BadRequest
 logger = logging.getLogger(__name__)
 
 
-def _unauthorized_exception_model(api: flask_restx.Api):
-    exception_details = {
-        "message": flask_restx.fields.String(
-            description="Description of the error.",
-            required=True,
-            example="This is a description of the error.",
-        )
-    }
-    return api.model("Unauthorized", exception_details)
-
-
-def add_unauthorized_exception_handler(api: flask_restx.Api):
+def add_error_handler(
+    api: flask_restx.Api, exception: Type[Exception], http_status: http.HTTPStatus
+):
     """
-    Add the Unauthorized Exception handler.
+    Subscribe error handler for the provided exception class.
 
-    :param api: The root Api
+    :param api: The Flask-RestX API that will handle this exception.
+    :param exception: The exception class to handle.
+    :param http_status: The http.HTTPStatus of the response.
+    :return: A tuple that can be used to document this error handler in flask_restx.
+    As in @api.response(*error_response)
     """
-    exception_model = _unauthorized_exception_model(api)
 
-    @api.errorhandler(Unauthorized)
-    @api.response(code=HTTPStatus.UNAUTHORIZED, description=None, model=exception_model)
-    def handle_exception(exception):
-        """This is the Unauthorized error handling."""
-        logger.exception(HTTPStatus.UNAUTHORIZED.description)
-        return {"message": str(exception)}, HTTPStatus.UNAUTHORIZED
-
-    return HTTPStatus.UNAUTHORIZED, HTTPStatus.UNAUTHORIZED.description, exception_model
-
-
-def add_forbidden_exception_handler(api: flask_restx.Api):
-    """
-    Add the Forbidden Exception handler.
-
-    :param api: The root Api
-    """
-    exception_model = _unauthorized_exception_model(api)
-
-    @api.errorhandler(Forbidden)
-    @api.response(code=HTTPStatus.FORBIDDEN, description=None, model=exception_model)
-    def handle_exception(exception):
-        """This is the Forbidden error handling."""
-        logger.exception(HTTPStatus.FORBIDDEN.description)
-        return {"message": str(exception)}, HTTPStatus.FORBIDDEN
-
-    return HTTPStatus.FORBIDDEN, HTTPStatus.FORBIDDEN.description, exception_model
-
-
-def _exception_model(api: flask_restx.Api):
-    exception_details = {
-        "message": flask_restx.fields.String(
-            description="Description of the error.",
-            required=True,
-            example="This is a description of the error.",
-        )
-    }
-    return api.model("Exception", exception_details)
-
-
-def add_exception_handler(api: flask_restx.Api):
-    """
-    Add the default Exception handler.
-
-    :param api: The root Api
-    """
-    exception_model = _exception_model(api)
-
-    @api.errorhandler(Exception)
+    @api.errorhandler(exception)
     @api.response(
-        code=HTTPStatus.INTERNAL_SERVER_ERROR, description=None, model=exception_model
+        code=http_status.value, description=None, model=flask_restx.fields.String
     )
-    def handle_exception(exception):
-        """This is the default error handling."""
-        logger.exception("An unexpected error occurred.")
-        return {"message": str(exception)}, HTTPStatus.INTERNAL_SERVER_ERROR
+    def handle_exception(e):
+        return str(e), http_status.value
 
-    return (
-        HTTPStatus.INTERNAL_SERVER_ERROR,
-        "An unexpected error occurred.",
-        exception_model,
-    )
-
-
-def _bad_request_exception_model(api: flask_restx.Api):
-    exception_details = {
-        "message": flask_restx.fields.String(
-            description="Description of the error.",
-            required=True,
-            example="This is a description of the error.",
-        )
-    }
-    return api.model("BadRequest", exception_details)
-
-
-def add_bad_request_exception_handler(api: flask_restx.Api):
-    """
-    Add the Bad Request Exception handler.
-
-    :param api: The root Api
-    """
-    exception_model = _bad_request_exception_model(api)
-
-    @api.errorhandler(BadRequest)
-    @api.response(code=HTTPStatus.BAD_REQUEST, description=None, model=exception_model)
-    def handle_exception(exception):
-        """This is the Bad Request error handling."""
-        logger.exception(HTTPStatus.BAD_REQUEST.description)
-        return {"message": str(exception)}, HTTPStatus.BAD_REQUEST
-
-    return HTTPStatus.BAD_REQUEST, HTTPStatus.BAD_REQUEST.description, exception_model
+    return http_status.value, http_status.description, flask_restx.fields.String
 
 
 class ValidationFailed(Exception):
@@ -143,54 +55,10 @@ class ValidationFailed(Exception):
     def __str__(self):
         return f"Errors: {self.errors}\nReceived: {self.received_data}"
 
-
-def _failed_field_validation_model(api: flask_restx.Api):
-    exception_details = {
-        "item": flask_restx.fields.Integer(
-            description="Position of the item that could not be validated.",
-            required=True,
-            example=1,
-        ),
-        "field_name": flask_restx.fields.String(
-            description="Name of the field that could not be validated.",
-            required=True,
-            example="sample_field_name",
-        ),
-        "messages": flask_restx.fields.List(
-            flask_restx.fields.String(
-                description="Reason why the validation failed.",
-                required=True,
-                example="This is the reason why this field was not validated.",
-            )
-        ),
-    }
-    return api.model("FieldValidationFailed", exception_details)
-
-
-def _failed_validation_model(api: flask_restx.Api):
-    exception_details = {
-        "fields": flask_restx.fields.List(
-            flask_restx.fields.Nested(_failed_field_validation_model(api))
-        )
-    }
-    return api.model("ValidationFailed", exception_details)
-
-
-def add_failed_validation_handler(api: flask_restx.Api):
-    """
-    Add the default ValidationFailed handler.
-
-    :param api: The root Api
-    """
-    exception_model = _failed_validation_model(api)
-
-    @api.errorhandler(ValidationFailed)
-    @api.response(code=400, description=None, model=exception_model)
-    def handle_exception(failed_validation):
-        """This is the default validation error handling."""
-        logger.exception("Validation failed.")
+    @staticmethod
+    def to_list(errors: dict) -> List[dict]:
         error_list = []
-        for field_name_or_index, messages_or_fields in failed_validation.errors.items():
+        for field_name_or_index, messages_or_fields in errors.items():
             if isinstance(messages_or_fields, dict):
                 error_list.extend(
                     [
@@ -210,9 +78,51 @@ def add_failed_validation_handler(api: flask_restx.Api):
                         "messages": messages_or_fields,
                     }
                 )
-        return {"fields": error_list}, 400
+        return error_list
 
-    return 400, "Validation failed.", exception_model
+    @staticmethod
+    def list_item_model():
+        return {
+            "item": flask_restx.fields.Integer(
+                description="Position of the item that could not be validated.",
+                example=1,
+            ),
+            "field_name": flask_restx.fields.String(
+                description="Name of the field that could not be validated.",
+                example="sample_field_name",
+            ),
+            "messages": flask_restx.fields.List(
+                flask_restx.fields.String(
+                    description="Reason why the validation failed.",
+                    example="This is the reason why this field was not validated.",
+                )
+            ),
+        }
+
+
+def add_failed_validation_handler(api: flask_restx.Api):
+    """
+    Subscribe error handler for the layaberr.flask_restx.ValidationFailed exception.
+
+    :param api: The Flask-RestX API that will handle this exception.
+    :return: A tuple that can be used to document this error handler in flask_restx.
+    As in @api.response(*error_response)
+    """
+    list_item_model = api.model("ValidationFailed", ValidationFailed.list_item_model())
+
+    @api.errorhandler(ValidationFailed)
+    @api.response(
+        code=http.HTTPStatus.BAD_REQUEST.value,
+        description=None,
+        model=[list_item_model],
+    )
+    def handle_exception(failed_validation):
+        return (
+            ValidationFailed.to_list(failed_validation.errors),
+            http.HTTPStatus.BAD_REQUEST.value,
+        )
+
+    return http.HTTPStatus.BAD_REQUEST.value, "Validation failed.", [list_item_model]
 
 
 def add_error_handlers(api: flask_restx.Api) -> Dict[str, dict]:
@@ -228,18 +138,18 @@ def add_error_handlers(api: flask_restx.Api) -> Dict[str, dict]:
     :return: A dictionary that can be used to document those error handlers in flask_restx.
     As in @api.doc(**error_responses)
     """
-    bad_request = add_bad_request_exception_handler(api)
+    bad_request = add_error_handler(api, BadRequest, http.HTTPStatus.BAD_REQUEST)
     failed_validation = add_failed_validation_handler(api)
-    unauthorized = add_unauthorized_exception_handler(api)
-    forbidden = add_forbidden_exception_handler(api)
-    exception = add_exception_handler(api)
+    unauthorized = add_error_handler(api, Unauthorized, http.HTTPStatus.UNAUTHORIZED)
+    forbidden = add_error_handler(api, Forbidden, http.HTTPStatus.FORBIDDEN)
+    exception = add_error_handler(api, Exception, http.HTTPStatus.INTERNAL_SERVER_ERROR)
 
     return {
         "responses": {
-            bad_request[0].value: (bad_request[1], bad_request[2]),
+            bad_request[0]: (bad_request[1], bad_request[2]),
             failed_validation[0]: (failed_validation[1], failed_validation[2]),
-            unauthorized[0].value: (unauthorized[1], unauthorized[2]),
-            forbidden[0].value: (forbidden[1], forbidden[2]),
-            exception[0].value: (exception[1], exception[2]),
+            unauthorized[0]: (unauthorized[1], unauthorized[2]),
+            forbidden[0]: (forbidden[1], forbidden[2]),
+            exception[0]: (exception[1], exception[2]),
         }
     }

--- a/layaberr/flask_restx.py
+++ b/layaberr/flask_restx.py
@@ -2,16 +2,16 @@ from typing import Union, List, Dict
 import logging
 from http import HTTPStatus
 
-from flask_restx import fields
+import flask_restx
 from werkzeug.exceptions import Unauthorized, Forbidden, BadRequest
 
 
 logger = logging.getLogger(__name__)
 
 
-def _unauthorized_exception_model(api):
+def _unauthorized_exception_model(api: flask_restx.Api):
     exception_details = {
-        "message": fields.String(
+        "message": flask_restx.fields.String(
             description="Description of the error.",
             required=True,
             example="This is a description of the error.",
@@ -20,7 +20,7 @@ def _unauthorized_exception_model(api):
     return api.model("Unauthorized", exception_details)
 
 
-def add_unauthorized_exception_handler(api):
+def add_unauthorized_exception_handler(api: flask_restx.Api):
     """
     Add the Unauthorized Exception handler.
 
@@ -38,7 +38,7 @@ def add_unauthorized_exception_handler(api):
     return HTTPStatus.UNAUTHORIZED, HTTPStatus.UNAUTHORIZED.description, exception_model
 
 
-def add_forbidden_exception_handler(api):
+def add_forbidden_exception_handler(api: flask_restx.Api):
     """
     Add the Forbidden Exception handler.
 
@@ -56,9 +56,9 @@ def add_forbidden_exception_handler(api):
     return HTTPStatus.FORBIDDEN, HTTPStatus.FORBIDDEN.description, exception_model
 
 
-def _exception_model(api):
+def _exception_model(api: flask_restx.Api):
     exception_details = {
-        "message": fields.String(
+        "message": flask_restx.fields.String(
             description="Description of the error.",
             required=True,
             example="This is a description of the error.",
@@ -67,7 +67,7 @@ def _exception_model(api):
     return api.model("Exception", exception_details)
 
 
-def add_exception_handler(api):
+def add_exception_handler(api: flask_restx.Api):
     """
     Add the default Exception handler.
 
@@ -89,9 +89,9 @@ def add_exception_handler(api):
     )
 
 
-def _bad_request_exception_model(api):
+def _bad_request_exception_model(api: flask_restx.Api):
     exception_details = {
-        "message": fields.String(
+        "message": flask_restx.fields.String(
             description="Description of the error.",
             required=True,
             example="This is a description of the error.",
@@ -100,7 +100,7 @@ def _bad_request_exception_model(api):
     return api.model("BadRequest", exception_details)
 
 
-def add_bad_request_exception_handler(api):
+def add_bad_request_exception_handler(api: flask_restx.Api):
     """
     Add the Bad Request Exception handler.
 
@@ -142,20 +142,20 @@ class ValidationFailed(Exception):
         return f"Errors: {self.errors}\nReceived: {self.received_data}"
 
 
-def _failed_field_validation_model(api):
+def _failed_field_validation_model(api: flask_restx.Api):
     exception_details = {
-        "item": fields.Integer(
+        "item": flask_restx.fields.Integer(
             description="Position of the item that could not be validated.",
             required=True,
             example=1,
         ),
-        "field_name": fields.String(
+        "field_name": flask_restx.fields.String(
             description="Name of the field that could not be validated.",
             required=True,
             example="sample_field_name",
         ),
-        "messages": fields.List(
-            fields.String(
+        "messages": flask_restx.fields.List(
+            flask_restx.fields.String(
                 description="Reason why the validation failed.",
                 required=True,
                 example="This is the reason why this field was not validated.",
@@ -165,14 +165,16 @@ def _failed_field_validation_model(api):
     return api.model("FieldValidationFailed", exception_details)
 
 
-def _failed_validation_model(api):
+def _failed_validation_model(api: flask_restx.Api):
     exception_details = {
-        "fields": fields.List(fields.Nested(_failed_field_validation_model(api)))
+        "fields": flask_restx.fields.List(
+            flask_restx.fields.Nested(_failed_field_validation_model(api))
+        )
     }
     return api.model("ValidationFailed", exception_details)
 
 
-def add_failed_validation_handler(api):
+def add_failed_validation_handler(api: flask_restx.Api):
     """
     Add the default ValidationFailed handler.
 
@@ -211,7 +213,19 @@ def add_failed_validation_handler(api):
     return 400, "Validation failed.", exception_model
 
 
-def add_error_handlers(api) -> Dict[str, dict]:
+def add_error_handlers(api: flask_restx.Api) -> Dict[str, dict]:
+    """
+    Subscribe error handlers for:
+        * werkzeug.exceptions.BadRequest
+        * layaberr.flask_restx.ValidationFailed
+        * werkzeug.exceptions.Unauthorized
+        * werkzeug.exceptions.Forbidden
+        * Exception
+
+    :param api: The Flask-RestX API that will handle those exceptions.
+    :return: A dictionary that can be used to document those error handlers in flask_restx.
+    As in @api.doc(**error_responses)
+    """
     bad_request = add_bad_request_exception_handler(api)
     failed_validation = add_failed_validation_handler(api)
     unauthorized = add_unauthorized_exception_handler(api)

--- a/layaberr/flask_restx.py
+++ b/layaberr/flask_restx.py
@@ -29,7 +29,7 @@ def add_unauthorized_exception_handler(api: flask_restx.Api):
     exception_model = _unauthorized_exception_model(api)
 
     @api.errorhandler(Unauthorized)
-    @api.marshal_with(exception_model, code=HTTPStatus.UNAUTHORIZED)
+    @api.response(code=HTTPStatus.UNAUTHORIZED, description=None, model=exception_model)
     def handle_exception(exception):
         """This is the Unauthorized error handling."""
         logger.exception(HTTPStatus.UNAUTHORIZED.description)
@@ -47,7 +47,7 @@ def add_forbidden_exception_handler(api: flask_restx.Api):
     exception_model = _unauthorized_exception_model(api)
 
     @api.errorhandler(Forbidden)
-    @api.marshal_with(exception_model, code=HTTPStatus.FORBIDDEN)
+    @api.response(code=HTTPStatus.FORBIDDEN, description=None, model=exception_model)
     def handle_exception(exception):
         """This is the Forbidden error handling."""
         logger.exception(HTTPStatus.FORBIDDEN.description)
@@ -76,7 +76,9 @@ def add_exception_handler(api: flask_restx.Api):
     exception_model = _exception_model(api)
 
     @api.errorhandler(Exception)
-    @api.marshal_with(exception_model, code=HTTPStatus.INTERNAL_SERVER_ERROR)
+    @api.response(
+        code=HTTPStatus.INTERNAL_SERVER_ERROR, description=None, model=exception_model
+    )
     def handle_exception(exception):
         """This is the default error handling."""
         logger.exception("An unexpected error occurred.")
@@ -109,7 +111,7 @@ def add_bad_request_exception_handler(api: flask_restx.Api):
     exception_model = _bad_request_exception_model(api)
 
     @api.errorhandler(BadRequest)
-    @api.marshal_with(exception_model, code=HTTPStatus.BAD_REQUEST)
+    @api.response(code=HTTPStatus.BAD_REQUEST, description=None, model=exception_model)
     def handle_exception(exception):
         """This is the Bad Request error handling."""
         logger.exception(HTTPStatus.BAD_REQUEST.description)
@@ -183,7 +185,7 @@ def add_failed_validation_handler(api: flask_restx.Api):
     exception_model = _failed_validation_model(api)
 
     @api.errorhandler(ValidationFailed)
-    @api.marshal_with(exception_model, code=400)
+    @api.response(code=400, description=None, model=exception_model)
     def handle_exception(failed_validation):
         """This is the default validation error handling."""
         logger.exception("Validation failed.")

--- a/layaberr/flask_restx.py
+++ b/layaberr/flask_restx.py
@@ -138,7 +138,7 @@ def add_error_handlers(api: flask_restx.Api) -> Dict[str, dict]:
     :return: A dictionary that can be used to document those error handlers in flask_restx.
     As in @api.doc(**error_responses)
     """
-    bad_request = add_error_handler(api, BadRequest, http.HTTPStatus.BAD_REQUEST)
+    add_error_handler(api, BadRequest, http.HTTPStatus.BAD_REQUEST)
     failed_validation = add_failed_validation_handler(api)
     unauthorized = add_error_handler(api, Unauthorized, http.HTTPStatus.UNAUTHORIZED)
     forbidden = add_error_handler(api, Forbidden, http.HTTPStatus.FORBIDDEN)
@@ -146,7 +146,6 @@ def add_error_handlers(api: flask_restx.Api) -> Dict[str, dict]:
 
     return {
         "responses": {
-            bad_request[0]: (bad_request[1], bad_request[2]),
             failed_validation[0]: (failed_validation[1], failed_validation[2]),
             unauthorized[0]: (unauthorized[1], unauthorized[2]),
             forbidden[0]: (forbidden[1], forbidden[2]),

--- a/layaberr/starlette.py
+++ b/layaberr/starlette.py
@@ -30,30 +30,16 @@ class Forbidden(HTTPException):
 
 async def http_exception(request: Request, exc: HTTPException):
     """
-    required:
-        - message
-    properties:
-        message:
-            type: string
-            description: Description of the error.
-            example: This is a description of the error.
-    type: object
+    type: string
     """
-    return JSONResponse({"message": exc.detail}, status_code=exc.status_code)
+    return JSONResponse(exc.detail, status_code=exc.status_code)
 
 
 async def exception(request: Request, exc: Exception):
     """
-    required:
-        - message
-    properties:
-        message:
-            type: string
-            description: Description of the error.
-            example: This is a description of the error.
-    type: object
+    type: string
     """
-    return JSONResponse({"message": str(exc)}, status_code=500)
+    return JSONResponse(str(exc), status_code=500)
 
 
 DictErrors = Dict[str, List[str]]
@@ -89,30 +75,27 @@ class ValidationFailed(HTTPException):
 
 async def validation_failed_exception(request: Request, exc: ValidationFailed):
     """
-    properties:
-        fields:
-            type: array
-            items:
-                required:
-                    - field_name
-                    - item
-                properties:
-                    item:
-                        type: integer
-                        description: Position of the item that could not be validated.
-                        example: 1
-                    field_name:
-                        type: string
-                        description: Name of the field that could not be validated.
-                        example: sample_field_name
-                    messages:
-                        type: array
-                        items:
-                            type: string
-                            description: Reason why the validation failed.
-                            example: This is the reason why this field was not validated.
-                type: object
-    type: object
+    type: array
+    items:
+        required:
+            - field_name
+            - item
+        properties:
+            item:
+                type: integer
+                description: Position of the item that could not be validated.
+                example: 1
+            field_name:
+                type: string
+                description: Name of the field that could not be validated.
+                example: sample_field_name
+            messages:
+                type: array
+                items:
+                    type: string
+                    description: Reason why the validation failed.
+                    example: This is the reason why this field was not validated.
+        type: object
     """
     error_list = []
     for field_name_or_index, messages_or_fields in exc.errors.items():
@@ -135,7 +118,7 @@ async def validation_failed_exception(request: Request, exc: ValidationFailed):
                     "messages": messages_or_fields,
                 }
             )
-    return JSONResponse({"fields": error_list}, status_code=exc.status_code)
+    return JSONResponse(error_list, status_code=exc.status_code)
 
 
 exception_handlers = {

--- a/layaberr/version.py
+++ b/layaberr/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "3.0.0.dev0"
+__version__ = "3.0.0.dev1"

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Build Tools",
     ],
     keywords=["error", "rest", "flask", "starlette"],
@@ -39,7 +40,7 @@ setup(
         "testing": [
             # Used to manage testing of a Flask application
             "flask-restx==0.2.*",
-            "pytest-flask==0.15.*",
+            "pytest-flask==1.*",
             # Used to manage testing of a Starlette application
             "starlette==0.13.*",
             "requests==2.*",

--- a/tests/test_flask_restx.py
+++ b/tests/test_flask_restx.py
@@ -1,7 +1,8 @@
+import http
+
 import pytest
 from flask import Flask
 from flask_restx import Resource, Api
-from werkzeug.exceptions import Unauthorized, BadRequest, Forbidden
 
 import layaberr.flask_restx
 
@@ -11,351 +12,75 @@ def app():
     application = Flask(__name__)
     application.testing = True
     application.config["PROPAGATE_EXCEPTIONS"] = False
+    application.config["ERROR_INCLUDE_MESSAGE"] = False
     api = Api(application)
 
-    bad_request_response = layaberr.flask_restx.add_bad_request_exception_handler(api)
-    unauthorized_response = layaberr.flask_restx.add_unauthorized_exception_handler(api)
-    forbidden_response = layaberr.flask_restx.add_forbidden_exception_handler(api)
-    validation_failed_response = layaberr.flask_restx.add_failed_validation_handler(api)
-    default_response = layaberr.flask_restx.add_exception_handler(api)
+    class CustomException(Exception):
+        pass
 
-    @api.route("/unauthorized")
-    class UnauthorizedError(Resource):
-        @api.response(*unauthorized_response)
-        @api.response(*default_response)
-        def get(self):
-            raise Unauthorized
+    custom_response = layaberr.flask_restx.add_error_handler(
+        api, CustomException, http.HTTPStatus.SERVICE_UNAVAILABLE
+    )
 
-    @api.route("/forbidden")
-    class ForbiddenError(Resource):
-        @api.response(*forbidden_response)
-        @api.response(*default_response)
+    @api.route("/custom")
+    @api.response(*custom_response)
+    class Custom(Resource):
         def get(self):
-            raise Forbidden
-
-    @api.route("/bad_request")
-    class BadRequestError(Resource):
-        @api.response(*bad_request_response)
-        @api.response(*default_response)
-        def get(self):
-            raise BadRequest
-
-    @api.route("/validation_failed_item")
-    class ValidationFailedItemError(Resource):
-        @api.response(*validation_failed_response)
-        @api.response(*default_response)
-        def get(self):
-            received_data = {"key 1": "value 1", "key 2": 1}
-            errors = {
-                "a field": ["an error"],
-                "another_field": ["first error", "second error"],
-            }
-            raise layaberr.flask_restx.ValidationFailed(received_data, errors=errors)
-
-    @api.route("/validation_failed_list")
-    class ValidationFailedListError(Resource):
-        @api.response(*validation_failed_response)
-        @api.response(*default_response)
-        def get(self):
-            received_data = [
-                {"key 1": "value 1", "key 2": 1},
-                {"key 1": "value 2", "key 2": 2},
-            ]
-            errors = {
-                0: {"a field": ["an error 1."]},
-                1: {
-                    "a field": ["an error 2."],
-                    "another_field": ["first error 2", "second error 2"],
-                },
-            }
-            raise layaberr.flask_restx.ValidationFailed(received_data, errors=errors)
-
-    @api.route("/default_error")
-    class DefaultError(Resource):
-        @api.response(*bad_request_response)
-        @api.response(*validation_failed_response)
-        @api.response(*unauthorized_response)
-        @api.response(*default_response)
-        def get(self):
-            raise Exception
+            raise CustomException("This is the error")
 
     return application
 
 
-def test_unauthorized(client):
-    response = client.get("/unauthorized")
-    assert response.status_code == 401
-    assert response.json == {
-        "message": "401 Unauthorized: The server could not verify that you are authorized to access the URL "
-        "requested. You either supplied the wrong credentials (e.g. a bad password), or your browser "
-        "doesn't understand how to supply the credentials required."
-    }
-
-
-def test_forbidden(client):
-    response = client.get("/forbidden")
-    assert response.status_code == 403
-    assert response.json == {
-        "message": "403 Forbidden: You don't have the permission to access the requested resource. It is either "
-        "read-protected or not readable by the server."
-    }
-
-
-def test_bad_request(client):
-    response = client.get("/bad_request")
-    assert response.status_code == 400
-    assert response.json == {
-        "message": "400 Bad Request: The browser (or proxy) sent a request that this server could not understand."
-    }
-
-
-def test_default(client):
-    response = client.get("/default_error")
-    assert response.status_code == 500
-    assert response.json == {"message": ""}
-
-
-def test_validation_failed_item(client):
-    response = client.get("/validation_failed_item")
-    assert response.status_code == 400
-    assert response.json == {
-        "fields": [
-            {"item": 1, "field_name": "a field", "messages": ["an error"]},
-            {
-                "item": 1,
-                "field_name": "another_field",
-                "messages": ["first error", "second error"],
-            },
-        ],
-        "message": "Errors: {'a field': ['an error'], 'another_field': ['first error', 'second error']}\n"
-        "Received: {'key 1': 'value 1', 'key 2': 1}",
-    }
-
-
-def test_validation_failed_list(client):
-    response = client.get("/validation_failed_list")
-    assert response.status_code == 400
-    assert response.json == {
-        "fields": [
-            {"item": 1, "field_name": "a field", "messages": ["an error 1."]},
-            {"item": 2, "field_name": "a field", "messages": ["an error 2."]},
-            {
-                "item": 2,
-                "field_name": "another_field",
-                "messages": ["first error 2", "second error 2"],
-            },
-        ],
-        "message": "Errors: {0: {'a field': ['an error 1.']}, 1: {'a field': ['an error 2.'], 'another_field': "
-        "['first error 2', 'second error 2']}}\n"
-        "Received: [{'key 1': 'value 1', 'key 2': 1}, {'key 1': 'value 2', 'key 2': 2}]",
-    }
+def test_custom_exception(client):
+    response = client.get("/custom")
+    assert response.status_code == 503
+    assert response.json == "This is the error"
 
 
 def test_open_api_definition(client):
     response = client.get("/swagger.json")
     assert response.json == {
-        "swagger": "2.0",
         "basePath": "/",
-        "paths": {
-            "/bad_request": {
-                "get": {
-                    "responses": {
-                        "HTTPStatus.INTERNAL_SERVER_ERROR": {
-                            "description": "An unexpected error occurred.",
-                            "schema": {"$ref": "#/definitions/Exception"},
-                        },
-                        "HTTPStatus.BAD_REQUEST": {
-                            "description": "Bad request syntax or unsupported method",
-                            "schema": {"$ref": "#/definitions/BadRequest"},
-                        },
-                    },
-                    "operationId": "get_bad_request_error",
-                    "tags": ["default"],
-                }
-            },
-            "/default_error": {
-                "get": {
-                    "responses": {
-                        "HTTPStatus.INTERNAL_SERVER_ERROR": {
-                            "description": "An unexpected error occurred.",
-                            "schema": {"$ref": "#/definitions/Exception"},
-                        },
-                        "HTTPStatus.UNAUTHORIZED": {
-                            "description": "No permission -- see authorization schemes",
-                            "schema": {"$ref": "#/definitions/Unauthorized"},
-                        },
-                        "400": {
-                            "description": "Validation failed.",
-                            "schema": {"$ref": "#/definitions/ValidationFailed"},
-                        },
-                        "HTTPStatus.BAD_REQUEST": {
-                            "description": "Bad request syntax or unsupported method",
-                            "schema": {"$ref": "#/definitions/BadRequest"},
-                        },
-                    },
-                    "operationId": "get_default_error",
-                    "tags": ["default"],
-                }
-            },
-            "/forbidden": {
-                "get": {
-                    "responses": {
-                        "HTTPStatus.INTERNAL_SERVER_ERROR": {
-                            "description": "An unexpected error occurred.",
-                            "schema": {"$ref": "#/definitions/Exception"},
-                        },
-                        "HTTPStatus.FORBIDDEN": {
-                            "description": "Request forbidden -- authorization will not help",
-                            "schema": {"$ref": "#/definitions/Unauthorized"},
-                        },
-                    },
-                    "operationId": "get_forbidden_error",
-                    "tags": ["default"],
-                }
-            },
-            "/unauthorized": {
-                "get": {
-                    "responses": {
-                        "HTTPStatus.INTERNAL_SERVER_ERROR": {
-                            "description": "An unexpected error occurred.",
-                            "schema": {"$ref": "#/definitions/Exception"},
-                        },
-                        "HTTPStatus.UNAUTHORIZED": {
-                            "description": "No permission -- see authorization schemes",
-                            "schema": {"$ref": "#/definitions/Unauthorized"},
-                        },
-                    },
-                    "operationId": "get_unauthorized_error",
-                    "tags": ["default"],
-                }
-            },
-            "/validation_failed_item": {
-                "get": {
-                    "responses": {
-                        "HTTPStatus.INTERNAL_SERVER_ERROR": {
-                            "description": "An unexpected error occurred.",
-                            "schema": {"$ref": "#/definitions/Exception"},
-                        },
-                        "400": {
-                            "description": "Validation failed.",
-                            "schema": {"$ref": "#/definitions/ValidationFailed"},
-                        },
-                    },
-                    "operationId": "get_validation_failed_item_error",
-                    "tags": ["default"],
-                }
-            },
-            "/validation_failed_list": {
-                "get": {
-                    "responses": {
-                        "HTTPStatus.INTERNAL_SERVER_ERROR": {
-                            "description": "An unexpected error occurred.",
-                            "schema": {"$ref": "#/definitions/Exception"},
-                        },
-                        "400": {
-                            "description": "Validation failed.",
-                            "schema": {"$ref": "#/definitions/ValidationFailed"},
-                        },
-                    },
-                    "operationId": "get_validation_failed_list_error",
-                    "tags": ["default"],
-                }
-            },
-        },
-        "info": {"title": "API", "version": "1.0"},
-        "produces": ["application/json"],
         "consumes": ["application/json"],
-        "tags": [{"name": "default", "description": "Default namespace"}],
-        "definitions": {
-            "BadRequest": {
-                "required": ["message"],
-                "properties": {
-                    "message": {
-                        "type": "string",
-                        "description": "Description of the error.",
-                        "example": "This is a description of the error.",
-                    }
-                },
-                "type": "object",
-            },
-            "Unauthorized": {
-                "required": ["message"],
-                "properties": {
-                    "message": {
-                        "type": "string",
-                        "description": "Description of the error.",
-                        "example": "This is a description of the error.",
-                    }
-                },
-                "type": "object",
-            },
-            "ValidationFailed": {
-                "properties": {
-                    "fields": {
-                        "type": "array",
-                        "items": {"$ref": "#/definitions/FieldValidationFailed"},
-                    }
-                },
-                "type": "object",
-            },
-            "FieldValidationFailed": {
-                "required": ["field_name", "item"],
-                "properties": {
-                    "item": {
-                        "type": "integer",
-                        "description": "Position of the item that could not be validated.",
-                        "example": 1,
+        "info": {"title": "API", "version": "1.0"},
+        "paths": {
+            "/custom": {
+                "get": {
+                    "operationId": "get_custom",
+                    "responses": {
+                        "503": {
+                            "description": "The "
+                            "server "
+                            "cannot "
+                            "process "
+                            "the "
+                            "request "
+                            "due to a "
+                            "high load",
+                            "schema": {"type": "string"},
+                        }
                     },
-                    "field_name": {
-                        "type": "string",
-                        "description": "Name of the field that could not be validated.",
-                        "example": "sample_field_name",
-                    },
-                    "messages": {
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "description": "Reason why the validation failed.",
-                            "example": "This is the reason why this field was not validated.",
-                        },
-                    },
-                },
-                "type": "object",
-            },
-            "Exception": {
-                "required": ["message"],
-                "properties": {
-                    "message": {
-                        "type": "string",
-                        "description": "Description of the error.",
-                        "example": "This is a description of the error.",
-                    }
-                },
-                "type": "object",
-            },
+                    "tags": ["default"],
+                }
+            }
         },
+        "produces": ["application/json"],
         "responses": {
-            "ParseError": {"description": "When a mask can't be parsed"},
+            "CustomException": {"schema": {"type": "string"}},
             "MaskError": {"description": "When any error occurs on mask"},
-            "BadRequest": {
-                "description": "This is the Bad Request error handling",
-                "schema": {"$ref": "#/definitions/BadRequest"},
-            },
-            "Unauthorized": {
-                "description": "This is the Unauthorized error handling",
-                "schema": {"$ref": "#/definitions/Unauthorized"},
-            },
-            "Forbidden": {
-                "description": "This is the Forbidden error handling",
-                "schema": {"$ref": "#/definitions/Unauthorized"},
-            },
-            "ValidationFailed": {
-                "description": "This is the default validation error handling",
-                "schema": {"$ref": "#/definitions/ValidationFailed"},
-            },
-            "Exception": {
-                "description": "This is the default error handling",
-                "schema": {"$ref": "#/definitions/Exception"},
-            },
+            "ParseError": {"description": "When a mask can't be parsed"},
         },
+        "swagger": "2.0",
+        "tags": [{"description": "Default namespace", "name": "default"}],
     }
+
+
+def test_validation_failed_str():
+    assert (
+        str(
+            layaberr.flask_restx.ValidationFailed(
+                {"field": "value"}, {"field": ["first error"]}
+            )
+        )
+        == """Errors: {'field': ['first error']}\nReceived: {'field': 'value'}"""
+    )

--- a/tests/test_flask_restx.py
+++ b/tests/test_flask_restx.py
@@ -149,3 +149,213 @@ def test_validation_failed_list(client):
         "['first error 2', 'second error 2']}}\n"
         "Received: [{'key 1': 'value 1', 'key 2': 1}, {'key 1': 'value 2', 'key 2': 2}]",
     }
+
+
+def test_open_api_definition(client):
+    response = client.get("/swagger.json")
+    assert response.json == {
+        "swagger": "2.0",
+        "basePath": "/",
+        "paths": {
+            "/bad_request": {
+                "get": {
+                    "responses": {
+                        "HTTPStatus.INTERNAL_SERVER_ERROR": {
+                            "description": "An unexpected error occurred.",
+                            "schema": {"$ref": "#/definitions/Exception"},
+                        },
+                        "HTTPStatus.BAD_REQUEST": {
+                            "description": "Bad request syntax or unsupported method",
+                            "schema": {"$ref": "#/definitions/BadRequest"},
+                        },
+                    },
+                    "operationId": "get_bad_request_error",
+                    "tags": ["default"],
+                }
+            },
+            "/default_error": {
+                "get": {
+                    "responses": {
+                        "HTTPStatus.INTERNAL_SERVER_ERROR": {
+                            "description": "An unexpected error occurred.",
+                            "schema": {"$ref": "#/definitions/Exception"},
+                        },
+                        "HTTPStatus.UNAUTHORIZED": {
+                            "description": "No permission -- see authorization schemes",
+                            "schema": {"$ref": "#/definitions/Unauthorized"},
+                        },
+                        "400": {
+                            "description": "Validation failed.",
+                            "schema": {"$ref": "#/definitions/ValidationFailed"},
+                        },
+                        "HTTPStatus.BAD_REQUEST": {
+                            "description": "Bad request syntax or unsupported method",
+                            "schema": {"$ref": "#/definitions/BadRequest"},
+                        },
+                    },
+                    "operationId": "get_default_error",
+                    "tags": ["default"],
+                }
+            },
+            "/forbidden": {
+                "get": {
+                    "responses": {
+                        "HTTPStatus.INTERNAL_SERVER_ERROR": {
+                            "description": "An unexpected error occurred.",
+                            "schema": {"$ref": "#/definitions/Exception"},
+                        },
+                        "HTTPStatus.FORBIDDEN": {
+                            "description": "Request forbidden -- authorization will not help",
+                            "schema": {"$ref": "#/definitions/Unauthorized"},
+                        },
+                    },
+                    "operationId": "get_forbidden_error",
+                    "tags": ["default"],
+                }
+            },
+            "/unauthorized": {
+                "get": {
+                    "responses": {
+                        "HTTPStatus.INTERNAL_SERVER_ERROR": {
+                            "description": "An unexpected error occurred.",
+                            "schema": {"$ref": "#/definitions/Exception"},
+                        },
+                        "HTTPStatus.UNAUTHORIZED": {
+                            "description": "No permission -- see authorization schemes",
+                            "schema": {"$ref": "#/definitions/Unauthorized"},
+                        },
+                    },
+                    "operationId": "get_unauthorized_error",
+                    "tags": ["default"],
+                }
+            },
+            "/validation_failed_item": {
+                "get": {
+                    "responses": {
+                        "HTTPStatus.INTERNAL_SERVER_ERROR": {
+                            "description": "An unexpected error occurred.",
+                            "schema": {"$ref": "#/definitions/Exception"},
+                        },
+                        "400": {
+                            "description": "Validation failed.",
+                            "schema": {"$ref": "#/definitions/ValidationFailed"},
+                        },
+                    },
+                    "operationId": "get_validation_failed_item_error",
+                    "tags": ["default"],
+                }
+            },
+            "/validation_failed_list": {
+                "get": {
+                    "responses": {
+                        "HTTPStatus.INTERNAL_SERVER_ERROR": {
+                            "description": "An unexpected error occurred.",
+                            "schema": {"$ref": "#/definitions/Exception"},
+                        },
+                        "400": {
+                            "description": "Validation failed.",
+                            "schema": {"$ref": "#/definitions/ValidationFailed"},
+                        },
+                    },
+                    "operationId": "get_validation_failed_list_error",
+                    "tags": ["default"],
+                }
+            },
+        },
+        "info": {"title": "API", "version": "1.0"},
+        "produces": ["application/json"],
+        "consumes": ["application/json"],
+        "tags": [{"name": "default", "description": "Default namespace"}],
+        "definitions": {
+            "BadRequest": {
+                "required": ["message"],
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": "Description of the error.",
+                        "example": "This is a description of the error.",
+                    }
+                },
+                "type": "object",
+            },
+            "Unauthorized": {
+                "required": ["message"],
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": "Description of the error.",
+                        "example": "This is a description of the error.",
+                    }
+                },
+                "type": "object",
+            },
+            "ValidationFailed": {
+                "properties": {
+                    "fields": {
+                        "type": "array",
+                        "items": {"$ref": "#/definitions/FieldValidationFailed"},
+                    }
+                },
+                "type": "object",
+            },
+            "FieldValidationFailed": {
+                "required": ["field_name", "item"],
+                "properties": {
+                    "item": {
+                        "type": "integer",
+                        "description": "Position of the item that could not be validated.",
+                        "example": 1,
+                    },
+                    "field_name": {
+                        "type": "string",
+                        "description": "Name of the field that could not be validated.",
+                        "example": "sample_field_name",
+                    },
+                    "messages": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "description": "Reason why the validation failed.",
+                            "example": "This is the reason why this field was not validated.",
+                        },
+                    },
+                },
+                "type": "object",
+            },
+            "Exception": {
+                "required": ["message"],
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": "Description of the error.",
+                        "example": "This is a description of the error.",
+                    }
+                },
+                "type": "object",
+            },
+        },
+        "responses": {
+            "ParseError": {"description": "When a mask can't be parsed"},
+            "MaskError": {"description": "When any error occurs on mask"},
+            "BadRequest": {
+                "description": "This is the Bad Request error handling",
+                "schema": {"$ref": "#/definitions/BadRequest"},
+            },
+            "Unauthorized": {
+                "description": "This is the Unauthorized error handling",
+                "schema": {"$ref": "#/definitions/Unauthorized"},
+            },
+            "Forbidden": {
+                "description": "This is the Forbidden error handling",
+                "schema": {"$ref": "#/definitions/Unauthorized"},
+            },
+            "ValidationFailed": {
+                "description": "This is the default validation error handling",
+                "schema": {"$ref": "#/definitions/ValidationFailed"},
+            },
+            "Exception": {
+                "description": "This is the default error handling",
+                "schema": {"$ref": "#/definitions/Exception"},
+            },
+        },
+    }

--- a/tests/test_flask_restx_all_errors_at_once.py
+++ b/tests/test_flask_restx_all_errors_at_once.py
@@ -137,3 +137,253 @@ def test_validation_failed_list(client):
         "['first error 2', 'second error 2']}}\n"
         "Received: [{'key 1': 'value 1', 'key 2': 1}, {'key 1': 'value 2', 'key 2': 2}]",
     }
+
+
+def test_open_api_definition(client):
+    response = client.get("/swagger.json")
+    assert response.json == {
+        "swagger": "2.0",
+        "basePath": "/",
+        "paths": {
+            "/bad_request": {
+                "get": {
+                    "responses": {
+                        "400": {
+                            "description": "Validation failed.",
+                            "schema": {"$ref": "#/definitions/ValidationFailed"},
+                        },
+                        "401": {
+                            "description": "No permission -- see authorization schemes",
+                            "schema": {"$ref": "#/definitions/Unauthorized"},
+                        },
+                        "403": {
+                            "description": "Request forbidden -- authorization will not help",
+                            "schema": {"$ref": "#/definitions/Unauthorized"},
+                        },
+                        "500": {
+                            "description": "An unexpected error occurred.",
+                            "schema": {"$ref": "#/definitions/Exception"},
+                        },
+                    },
+                    "operationId": "get_bad_request_error",
+                    "tags": ["default"],
+                }
+            },
+            "/default_error": {
+                "get": {
+                    "responses": {
+                        "400": {
+                            "description": "Validation failed.",
+                            "schema": {"$ref": "#/definitions/ValidationFailed"},
+                        },
+                        "401": {
+                            "description": "No permission -- see authorization schemes",
+                            "schema": {"$ref": "#/definitions/Unauthorized"},
+                        },
+                        "403": {
+                            "description": "Request forbidden -- authorization will not help",
+                            "schema": {"$ref": "#/definitions/Unauthorized"},
+                        },
+                        "500": {
+                            "description": "An unexpected error occurred.",
+                            "schema": {"$ref": "#/definitions/Exception"},
+                        },
+                    },
+                    "operationId": "get_default_error",
+                    "tags": ["default"],
+                }
+            },
+            "/forbidden": {
+                "get": {
+                    "responses": {
+                        "400": {
+                            "description": "Validation failed.",
+                            "schema": {"$ref": "#/definitions/ValidationFailed"},
+                        },
+                        "401": {
+                            "description": "No permission -- see authorization schemes",
+                            "schema": {"$ref": "#/definitions/Unauthorized"},
+                        },
+                        "403": {
+                            "description": "Request forbidden -- authorization will not help",
+                            "schema": {"$ref": "#/definitions/Unauthorized"},
+                        },
+                        "500": {
+                            "description": "An unexpected error occurred.",
+                            "schema": {"$ref": "#/definitions/Exception"},
+                        },
+                    },
+                    "operationId": "get_forbidden_error",
+                    "tags": ["default"],
+                }
+            },
+            "/unauthorized": {
+                "get": {
+                    "responses": {
+                        "400": {
+                            "description": "Validation failed.",
+                            "schema": {"$ref": "#/definitions/ValidationFailed"},
+                        },
+                        "401": {
+                            "description": "No permission -- see authorization schemes",
+                            "schema": {"$ref": "#/definitions/Unauthorized"},
+                        },
+                        "403": {
+                            "description": "Request forbidden -- authorization will not help",
+                            "schema": {"$ref": "#/definitions/Unauthorized"},
+                        },
+                        "500": {
+                            "description": "An unexpected error occurred.",
+                            "schema": {"$ref": "#/definitions/Exception"},
+                        },
+                    },
+                    "operationId": "get_unauthorized_error",
+                    "tags": ["default"],
+                }
+            },
+            "/validation_failed_item": {
+                "get": {
+                    "responses": {
+                        "400": {
+                            "description": "Validation failed.",
+                            "schema": {"$ref": "#/definitions/ValidationFailed"},
+                        },
+                        "401": {
+                            "description": "No permission -- see authorization schemes",
+                            "schema": {"$ref": "#/definitions/Unauthorized"},
+                        },
+                        "403": {
+                            "description": "Request forbidden -- authorization will not help",
+                            "schema": {"$ref": "#/definitions/Unauthorized"},
+                        },
+                        "500": {
+                            "description": "An unexpected error occurred.",
+                            "schema": {"$ref": "#/definitions/Exception"},
+                        },
+                    },
+                    "operationId": "get_validation_failed_item_error",
+                    "tags": ["default"],
+                }
+            },
+            "/validation_failed_list": {
+                "get": {
+                    "responses": {
+                        "400": {
+                            "description": "Validation failed.",
+                            "schema": {"$ref": "#/definitions/ValidationFailed"},
+                        },
+                        "401": {
+                            "description": "No permission -- see authorization schemes",
+                            "schema": {"$ref": "#/definitions/Unauthorized"},
+                        },
+                        "403": {
+                            "description": "Request forbidden -- authorization will not help",
+                            "schema": {"$ref": "#/definitions/Unauthorized"},
+                        },
+                        "500": {
+                            "description": "An unexpected error occurred.",
+                            "schema": {"$ref": "#/definitions/Exception"},
+                        },
+                    },
+                    "operationId": "get_validation_failed_list_error",
+                    "tags": ["default"],
+                }
+            },
+        },
+        "info": {"title": "API", "version": "1.0"},
+        "produces": ["application/json"],
+        "consumes": ["application/json"],
+        "tags": [{"name": "default", "description": "Default namespace"}],
+        "definitions": {
+            "BadRequest": {
+                "required": ["message"],
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": "Description of the error.",
+                        "example": "This is a description of the error.",
+                    }
+                },
+                "type": "object",
+            },
+            "ValidationFailed": {
+                "properties": {
+                    "fields": {
+                        "type": "array",
+                        "items": {"$ref": "#/definitions/FieldValidationFailed"},
+                    }
+                },
+                "type": "object",
+            },
+            "FieldValidationFailed": {
+                "required": ["field_name", "item"],
+                "properties": {
+                    "item": {
+                        "type": "integer",
+                        "description": "Position of the item that could not be validated.",
+                        "example": 1,
+                    },
+                    "field_name": {
+                        "type": "string",
+                        "description": "Name of the field that could not be validated.",
+                        "example": "sample_field_name",
+                    },
+                    "messages": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "description": "Reason why the validation failed.",
+                            "example": "This is the reason why this field was not validated.",
+                        },
+                    },
+                },
+                "type": "object",
+            },
+            "Unauthorized": {
+                "required": ["message"],
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": "Description of the error.",
+                        "example": "This is a description of the error.",
+                    }
+                },
+                "type": "object",
+            },
+            "Exception": {
+                "required": ["message"],
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": "Description of the error.",
+                        "example": "This is a description of the error.",
+                    }
+                },
+                "type": "object",
+            },
+        },
+        "responses": {
+            "ParseError": {"description": "When a mask can't be parsed"},
+            "MaskError": {"description": "When any error occurs on mask"},
+            "BadRequest": {
+                "description": "This is the Bad Request error handling",
+                "schema": {"$ref": "#/definitions/BadRequest"},
+            },
+            "ValidationFailed": {
+                "description": "This is the default validation error handling",
+                "schema": {"$ref": "#/definitions/ValidationFailed"},
+            },
+            "Unauthorized": {
+                "description": "This is the Unauthorized error handling",
+                "schema": {"$ref": "#/definitions/Unauthorized"},
+            },
+            "Forbidden": {
+                "description": "This is the Forbidden error handling",
+                "schema": {"$ref": "#/definitions/Unauthorized"},
+            },
+            "Exception": {
+                "description": "This is the default error handling",
+                "schema": {"$ref": "#/definitions/Exception"},
+            },
+        },
+    }

--- a/tests/test_starlette_authorization.py
+++ b/tests/test_starlette_authorization.py
@@ -31,24 +31,22 @@ def client():
 def test_unauthorized(client):
     response = client.get("/unauthorized")
     assert response.status_code == 401
-    assert response.json() == {"message": "No permission -- see authorization schemes"}
+    assert response.json() == "No permission -- see authorization schemes"
 
 
 def test_unauthorized_detail(client):
     response = client.get("/unauthorized_detail")
     assert response.status_code == 401
-    assert response.json() == {"message": "Error message"}
+    assert response.json() == "Error message"
 
 
 def test_forbidden(client):
     response = client.get("/forbidden")
     assert response.status_code == 403
-    assert response.json() == {
-        "message": "Request forbidden -- authorization will not help"
-    }
+    assert response.json() == "Request forbidden -- authorization will not help"
 
 
 def test_forbidden_detail(client):
     response = client.get("/forbidden_detail")
     assert response.status_code == 403
-    assert response.json() == {"message": "Error message"}
+    assert response.json() == "Error message"

--- a/tests/test_starlette_default.py
+++ b/tests/test_starlette_default.py
@@ -40,4 +40,4 @@ def test_bad_request_detail(client):
 def test_default(client):
     response = client.get("/default_error")
     assert response.status_code == 500
-    assert response.json() == {"message": ""}
+    assert response.json() == ""

--- a/tests/test_starlette_validation.py
+++ b/tests/test_starlette_validation.py
@@ -43,37 +43,33 @@ def client():
 def test_validation_failed_item(client):
     response = client.get("/validation_failed_item")
     assert response.status_code == 400
-    assert response.json() == {
-        "fields": [
-            {"item": 1, "field_name": "a field", "messages": ["an error"]},
-            {
-                "item": 1,
-                "field_name": "another_field",
-                "messages": ["first error", "second error"],
-            },
-        ]
-    }
+    assert response.json() == [
+        {"item": 1, "field_name": "a field", "messages": ["an error"]},
+        {
+            "item": 1,
+            "field_name": "another_field",
+            "messages": ["first error", "second error"],
+        },
+    ]
 
 
 def test_validation_failed_list(client):
     response = client.get("/validation_failed_list")
     assert response.status_code == 400
-    assert response.json() == {
-        "fields": [
-            {"item": 1, "field_name": "a field", "messages": ["an error 1."]},
-            {"item": 2, "field_name": "a field", "messages": ["an error 2."]},
-            {
-                "item": 2,
-                "field_name": "another_field",
-                "messages": ["first error 2", "second error 2"],
-            },
-        ]
-    }
+    assert response.json() == [
+        {"item": 1, "field_name": "a field", "messages": ["an error 1."]},
+        {"item": 2, "field_name": "a field", "messages": ["an error 2."]},
+        {
+            "item": 2,
+            "field_name": "another_field",
+            "messages": ["first error 2", "second error 2"],
+        },
+    ]
 
 
 def test_validation_failed_message(client):
     response = client.get("/validation_failed_message")
     assert response.status_code == 400
-    assert response.json() == {
-        "fields": [{"field_name": "", "item": 1, "messages": ["Error message"]}]
-    }
+    assert response.json() == [
+        {"field_name": "", "item": 1, "messages": ["Error message"]}
+    ]


### PR DESCRIPTION
### Added
- Explicit support for Python 3.9
- Added `layaberr.flask_restx.add_error_handler` function to return a string representation of an error as a specific HTTP error.

### Fixed
- Add documentation to `layaberr.flask_restx.add_error_handlers`.

### Changed
- `layaberr.flask_restx.add_bad_request_exception_handler` will now raise a JSON string as a response. Instead of a JSON dict with the string value linked to `message` key.
- `layaberr.flask_restx.add_unauthorized_exception_handler` will now raise a JSON string as a response. Instead of a JSON dict with the string value linked to `message` key.
- `layaberr.flask_restx.add_forbidden_exception_handler` will now raise a JSON string as a response. Instead of a JSON dict with the string value linked to `message` key.
- `layaberr.flask_restx.add_exception_handler` will now raise a JSON string as a response. Instead of a JSON dict with the string value linked to `message` key.
- `layaberr.flask_restx.add_failed_validation_handler` will not contains `message` key anymore and the content of `fields` key will not be the JSON response. So a list is now returned instead of a dict containing a list.

### Removed
- `layaberr.flask_restx` will not log exceptions anymore. Logging is deferred to the REST API.
- `layaberr.flask_restx.add_bad_request_exception_handler` is not available anymore.
- `layaberr.flask_restx.add_unauthorized_exception_handler` is not available anymore.
- `layaberr.flask_restx.add_forbidden_exception_handler` is not available anymore.
- `layaberr.flask_restx.add_exception_handler` is not available anymore.
